### PR TITLE
Adjust the version number in package.json for 7.x branch.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-langserver",
-  "version": "8.0.0-SNAPSHOT",
+  "version": "7.4.0-SNAPSHOT",
   "description": "Code Plugin Go Language Server",
   "main": "index.js",
   "kibana": {


### PR DESCRIPTION
This PR will fix the version number inconsistent issue, https://github.com/elastic/release-manager/pull/667#issuecomment-525977666.